### PR TITLE
Add proxy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(Source
     "./src/dx_deferred_update.c"	
     "./src/dx_avnet_iot_connect.c"	
     "./src/dx_uart.c"
+    "./src/dx_proxy.c"
 )
 source_group("Source" FILES ${Source})
 

--- a/include/dx_azure_iot.h
+++ b/include/dx_azure_iot.h
@@ -16,6 +16,8 @@
 #include "dx_utilities.h"
 #include "dx_avnet_iot_connect.h"
 #include "iothubtransportmqtt.h"
+#include <iothubtransportmqtt_websockets.h>
+#include <azure_prov_client/prov_transport_mqtt_ws_client.h>
 #include <applibs/log.h>
 #include <azure_prov_client/iothub_security_factory.h>
 #include <azure_sphere_provisioning.h>
@@ -45,6 +47,16 @@ typedef struct DX_MESSAGE_CONTENT_PROPERTIES {
     const char *contentEncoding;
     const char *contentType;
 } DX_MESSAGE_CONTENT_PROPERTIES;
+
+typedef struct DX_PROXY_PROPERTIES{
+    const char *proxyAddress;       // The Proxy Server Address
+    const uint16_t proxyPort;       // The Proxy Server Port
+    const char *proxyUsername;      // Proxy Username (basic auth), or NULL to use anonymous auth
+    const char *proxyPassword;      // Proxy Password (basic auth), or NULL to use anponymous auth
+    const char *noProxyAdresses;    // Comma seperated list of IP address' that should NOT be routed
+                                    //   to the proxy
+    const bool proxyEnabled;                                    
+} DX_PROXY_PROPERTIES;
 
 /// <summary>
 /// Check if there is a network connection and an authenticated connection to Azure IoT Hub/Central
@@ -123,3 +135,18 @@ void dx_azureRegisterDeviceTwinCallback(void (*deviceTwinCallbackHandler)(DEVICE
 void dx_azureRegisterDirectMethodCallback(int (*directMethodCallbackHandler)(const char *method_name, const unsigned char *payload,
                                                                              size_t payloadSize, unsigned char **responsePayload,
                                                                              size_t *responsePayloadSize, void *userContextCallback));
+
+/// <summary>
+/// Configure Proxy Settings
+/// </summary>
+/// <param name="proxyProperties"></param>
+void dx_azureConfigureProxy(DX_PROXY_PROPERTIES *proxyProperties);
+
+/// <summary>
+/// Enable or disable an already configured proxy.
+/// </summary>
+/// <param name="enableProxy">To enable or disable proxy. Set to true to enable, and false to
+/// disable proxy</param>
+void dx_azureEnableProxy(bool enableProxy);  
+
+

--- a/include/dx_azure_iot.h
+++ b/include/dx_azure_iot.h
@@ -15,6 +15,7 @@
 #include "dx_timer.h"
 #include "dx_utilities.h"
 #include "dx_avnet_iot_connect.h"
+#include "dx_proxy.h"
 #include "iothubtransportmqtt.h"
 #include <iothubtransportmqtt_websockets.h>
 #include <azure_prov_client/prov_transport_mqtt_ws_client.h>
@@ -47,16 +48,6 @@ typedef struct DX_MESSAGE_CONTENT_PROPERTIES {
     const char *contentEncoding;
     const char *contentType;
 } DX_MESSAGE_CONTENT_PROPERTIES;
-
-typedef struct DX_PROXY_PROPERTIES{
-    const char *proxyAddress;       // The Proxy Server Address
-    const uint16_t proxyPort;       // The Proxy Server Port
-    const char *proxyUsername;      // Proxy Username (basic auth), or NULL to use anonymous auth
-    const char *proxyPassword;      // Proxy Password (basic auth), or NULL to use anponymous auth
-    const char *noProxyAdresses;    // Comma seperated list of IP address' that should NOT be routed
-                                    //   to the proxy
-    const bool proxyEnabled;                                    
-} DX_PROXY_PROPERTIES;
 
 /// <summary>
 /// Check if there is a network connection and an authenticated connection to Azure IoT Hub/Central
@@ -135,18 +126,5 @@ void dx_azureRegisterDeviceTwinCallback(void (*deviceTwinCallbackHandler)(DEVICE
 void dx_azureRegisterDirectMethodCallback(int (*directMethodCallbackHandler)(const char *method_name, const unsigned char *payload,
                                                                              size_t payloadSize, unsigned char **responsePayload,
                                                                              size_t *responsePayloadSize, void *userContextCallback));
-
-/// <summary>
-/// Configure Proxy Settings
-/// </summary>
-/// <param name="proxyProperties"></param>
-void dx_azureConfigureProxy(DX_PROXY_PROPERTIES *proxyProperties);
-
-/// <summary>
-/// Enable or disable an already configured proxy.
-/// </summary>
-/// <param name="enableProxy">To enable or disable proxy. Set to true to enable, and false to
-/// disable proxy</param>
-void dx_azureEnableProxy(bool enableProxy);  
 
 

--- a/include/dx_exit_codes.h
+++ b/include/dx_exit_codes.h
@@ -63,4 +63,7 @@ typedef enum {
     DX_ExitCode_I2C_SetTimeout_Failed = 207,
 
 	DX_ExitCode_Create_Timer_Failed = 206,
+	
+	DX_ExitCode_Configure_Proxy_Failed = 205,
+	DX_ExitCode_Enable_Disable_Proxy_Failed = 204,
 } ExitCode;

--- a/include/dx_proxy.h
+++ b/include/dx_proxy.h
@@ -1,0 +1,53 @@
+/* Copyright (c) Avnet Incorporated. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+#include <iothubtransportmqtt_websockets.h>
+#include <azure_prov_client/prov_transport_mqtt_ws_client.h>
+#include <applibs/log.h>
+#include <azure_sphere_provisioning.h>
+#include "dx_terminate.h"
+#include "dx_utilities.h"
+
+typedef struct DX_PROXY_PROPERTIES{
+    const char *proxyAddress;       // The Proxy Server Address, or FQDN
+    const uint16_t proxyPort;       // The Proxy Server Port
+    const char *proxyUsername;      // Proxy Username (basic auth), or NULL to use anonymous auth
+    const char *proxyPassword;      // Proxy Password (basic auth), or NULL to use anponymous auth
+    const char *noProxyAdresses;    // Comma seperated list of IP address' that should NOT be routed
+                                    //   to the proxy
+    bool proxyEnabled;                                    
+} DX_PROXY_PROPERTIES;
+
+/// <summary>
+/// Create the DPS provisioning handle using MQTT over a Web Socket.  Required when the Sphere 
+/// device is using a web proxy
+/// </summary>
+/// <param name="prov_handle"></param>
+bool dx_proxyCreateDpsClientWithMqttWebSocket(const char *dpsUrl, const char *idScope, PROV_DEVICE_LL_HANDLE *prov_handle);
+
+/// <summary>
+/// Establish IoTHub connection using MQTT WebSocket.  Required when the Sphere device is using a web proxy
+/// </summary>
+/// <param name="proxyProperties"></param>
+bool dx_proxyOpenIoTHubHandleWithMqttWebSocket(const char *hostname,
+                                               IOTHUB_DEVICE_CLIENT_LL_HANDLE *iothubClientHandle);
+
+/// <summary>
+/// Return the status of the web proxy, enabled (true) or disabled (false).
+/// </summary>
+bool dx_proxyIsEnabled(void);
+
+/// <summary>
+/// Configure Proxy Settings
+/// </summary>
+/// <param name="proxyProperties"></param>
+void dx_proxyConfigureProxy(DX_PROXY_PROPERTIES *proxyProperties);
+
+/// <summary>
+/// Enable or disable an already configured proxy.
+/// </summary>
+/// <param name="enableProxy">To enable or disable proxy. Set to true to enable, and false to
+/// disable proxy</param>
+void dx_proxyEnableProxy(bool enableProxy);

--- a/src/dx_azure_iot.c
+++ b/src/dx_azure_iot.c
@@ -16,6 +16,7 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE iothubClientHandle = NULL;
 static char *iotHubUri = NULL;
 static const char *_networkInterface = NULL;
 static DX_USER_CONFIG *_userConfig = NULL;
+static DX_PROXY_PROPERTIES *_proxyConfig = NULL;
 static int outstandingMessageCount = 0;
 static bool connection_initialized = false;
 
@@ -170,22 +171,26 @@ void dx_azureConnect(DX_USER_CONFIG *userConfig, const char *networkInterface, c
         return;
     }
 
+    // Verify that a connection type is definedf
     if (userConfig->connectionType == DX_CONNECTION_TYPE_NOT_DEFINED) {
         Log_Debug("ERROR: Connection type not defined\n");
         dx_terminate(DX_ExitCode_Validate_Connection_Type_Not_Defined);
         return;
     }
 
+    // Set private pointers to the application configuration structures
     _userConfig = userConfig;
     _networkInterface = networkInterface;
     _pnpModelId = plugAndPlayModelId;
 
+    // Create a JSON key value pair with the PnP model details "{"modelId":"PassedInModelIDString"};
     if (_userConfig->connectionType == DX_CONNECTION_TYPE_DPS) {
         if (!createPnpModelIdJson()) {
             return;
         }
     }
 
+    // Start the timer that drives the Azure connection process
     dx_azureToDeviceStart();
 
     connection_initialized = true;
@@ -257,7 +262,9 @@ static void AzureConnectionHandler(EventLoopTimer *eventLoopTimer)
         deviceConnectionState = DEVICE_NOT_CONNECTED;
     }
 
+    // Use the current connection state to determine what to do next
     switch (iotHubClientAuthenticationState) {
+        // This is the start state when we first run
     case IoTHubClientAuthenticationState_NotAuthenticated:
         SetupAzureClient();
         nextEventPeriod = (struct timespec){1, 0};
@@ -442,10 +449,37 @@ static bool ConnectToIotHub(const char *hostname)
         return false;
     }
 
-    if ((iothubClientHandle = IoTHubDeviceClient_LL_CreateWithAzureSphereFromDeviceAuth(hostname, &MQTT_Protocol)) == NULL) {
-        Log_Debug("ERROR: Failed to create client IoT Hub Client Handle\n");
-        return false;
+    if((_proxyConfig->proxyEnabled) && (_proxyConfig->proxyAddress != NULL)){
+
+        iothubClientHandle =
+            IoTHubDeviceClient_LL_CreateWithAzureSphereFromDeviceAuth(hostname, MQTT_WebSocket_Protocol);
+
+        if (iothubClientHandle == NULL) {
+            Log_Debug("ERROR: IoTHubDeviceClient_LL_CreateFromDeviceAuth returned NULL.\n");
+            return false;
+        }
+
+        IOTHUB_CLIENT_RESULT iothubResult;
+
+        HTTP_PROXY_OPTIONS httpProxyOptions;
+        memset(&httpProxyOptions, 0, sizeof(httpProxyOptions));
+        httpProxyOptions.host_address = _proxyConfig->proxyAddress;
+        httpProxyOptions.port = _proxyConfig->proxyPort;
+
+        if ((iothubResult = IoTHubDeviceClient_LL_SetOption(
+            iothubClientHandle, OPTION_HTTP_PROXY, &httpProxyOptions)) != IOTHUB_CLIENT_OK) {
+            Log_Debug("ERROR: Failure setting Azure IoT Hub client option  \"OPTION_HTTP_PROXY\": %s\n",
+                IOTHUB_CLIENT_RESULTStrings(iothubResult));
+                return false;
+        }
     }
+    // Proxy not enabled
+    else{
+        if ((iothubClientHandle = IoTHubDeviceClient_LL_CreateWithAzureSphereFromDeviceAuth(hostname, &MQTT_Protocol)) == NULL) {
+            Log_Debug("ERROR: Failed to create client IoT Hub Client Handle\n");
+            return false;
+        }
+    }    
 
     // IOTHUB_CLIENT_RESULT iothub_result
     if ((iothubResult = IoTHubDeviceClient_LL_SetOption(iothubClientHandle, "SetDeviceId", &deviceIdForDaaCertUsage)) != IOTHUB_CLIENT_OK) {
@@ -568,13 +602,47 @@ static bool SetUpAzureIoTHubClientWithDaaDpsPnP(void)
 
         security_init_called = true;
 
-        // Create Provisioning Client for communication with DPS using MQTT protocol
-        if ((prov_handle = Prov_Device_LL_Create(dpsUrl, _userConfig->idScope, Prov_Device_MQTT_Protocol)) == NULL) {
-            Log_Debug("ERROR: Failed to create Provisioning Client\n");
-            deviceConnectionState = DEVICE_PROVISIONING_ERROR;
-            goto cleanup;
-        }
+        // Check to see if we're using the web proxy
+        if((_proxyConfig->proxyEnabled) && (_proxyConfig->proxyAddress != NULL)){
 
+            // Create Provisioning Client for communication with DPS
+            // using MQTT protocol
+            prov_handle = Prov_Device_LL_Create(dpsUrl,  _userConfig->idScope, Prov_Device_MQTT_WS_Protocol);
+            if (prov_handle == NULL) {
+                Log_Debug("ERROR: Failed to create Provisioning Client\n");
+                goto cleanup;
+            }
+
+            // Use DAA cert in provisioning flow - requires the SetDeviceId option to be set on the
+            // provisioning client.
+            static const int deviceIdForDaaCertUsage = 1;
+            PROV_DEVICE_RESULT prov_result =
+                Prov_Device_LL_SetOption(prov_handle, "SetDeviceId", &deviceIdForDaaCertUsage);
+            if (prov_result != PROV_DEVICE_RESULT_OK) {
+                Log_Debug("ERROR: Failed to set Device ID in Provisioning Client\n");
+                goto cleanup;
+            }
+
+            HTTP_PROXY_OPTIONS httpProxyOptions;
+            memset(&httpProxyOptions, 0, sizeof(httpProxyOptions));
+            httpProxyOptions.host_address = _proxyConfig->proxyAddress;
+            httpProxyOptions.port = _proxyConfig->proxyPort;
+            prov_result = Prov_Device_LL_SetOption(prov_handle, OPTION_HTTP_PROXY, &httpProxyOptions);
+            if (prov_result != PROV_DEVICE_RESULT_OK) {
+                Log_Debug("ERROR: Failed to set Proxy options in Provisioning Client\n");
+                goto cleanup;
+            }
+        }
+        // Not using a web proxy
+        else{
+
+            // Create Provisioning Client for communication with DPS using MQTT protocol
+            if ((prov_handle = Prov_Device_LL_Create(dpsUrl, _userConfig->idScope, Prov_Device_MQTT_Protocol)) == NULL) {
+                Log_Debug("ERROR: Failed to create Provisioning Client\n");
+                deviceConnectionState = DEVICE_PROVISIONING_ERROR;
+                goto cleanup;
+            }
+        }
         // Sets Device ID on Provisioning Client
         if ((prov_result = Prov_Device_LL_SetOption(prov_handle, "SetDeviceId", &deviceIdForDaaCertUsage)) != PROV_DEVICE_RESULT_OK) {
             Log_Debug("ERROR: Failed to set Device ID in Provisioning Client, error=%d\n", prov_result);
@@ -750,4 +818,138 @@ static const char *GetReasonString(IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason
         break;
     }
     return reasonString;
+}
+
+/// <summary>
+/// Configure Proxy Settings
+/// </summary>
+/// <param name="proxyProperties"></param>
+void dx_azureConfigureProxy(DX_PROXY_PROPERTIES *proxyProperties)
+{
+    int result = -1;
+
+    // Capture a pointer to the incomming proxyProperties
+    _proxyConfig = proxyProperties;
+
+    // By default, proxy configuration option Networking_ProxyOptions_Enabled is set and the proxy
+    // type is Networking_ProxyType_HTTP.
+    Networking_ProxyConfig *proxyConfig = Networking_Proxy_Create();
+    if (proxyConfig == NULL) {
+        Log_Debug("ERROR: Networking_Proxy_Create(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Set the proxy address and port.
+    if (Networking_Proxy_SetProxyAddress(proxyConfig, proxyProperties->proxyAddress, proxyProperties->proxyPort) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_SetProxyAddress(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // If both username and password are set, use basic authentication. Otherwise use anonymous
+    // authentication.
+    if ((proxyProperties->proxyUsername != NULL) && (proxyProperties->proxyPassword != NULL)) {
+        if (Networking_Proxy_SetBasicAuthentication(proxyConfig, proxyProperties->proxyUsername, proxyProperties->proxyPassword) ==
+            -1) {
+            Log_Debug("ERROR: Networking_Proxy_SetBasicAuthentication(): %d (%s)\n", errno,
+                      strerror(errno));
+            goto cleanup;
+        }
+    } else {
+        if (Networking_Proxy_SetAnonymousAuthentication(proxyConfig) == -1) {
+            Log_Debug("ERROR: Networking_Proxy_SetAnonymousAuthentication(): %d (%s)\n", errno,
+                      strerror(errno));
+            goto cleanup;
+        }
+    }
+
+    // Set addresses for which proxy should not be used if "noProxyAddresses" is modified.
+    if (proxyProperties->noProxyAdresses != NULL) {
+        if (Networking_Proxy_SetProxyNoProxyAddresses(proxyConfig, proxyProperties->noProxyAdresses) == -1) {
+            Log_Debug("ERROR: Networking_Proxy_SetProxyNoProxyAddresses(): %d (%s)\n", errno,
+                      strerror(errno));
+            goto cleanup;
+        }
+    }
+
+    // Apply the proxy configuration.
+    if (Networking_Proxy_Apply(proxyConfig) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_Apply(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+    result = 0;
+
+cleanup:
+    if (proxyConfig) {
+        Networking_Proxy_Destroy(proxyConfig);
+    }
+
+    // If we encountered any errors exit and return the exit reason to the OS
+    if(result != 0){
+        dx_terminate(DX_ExitCode_Configure_Proxy_Failed);
+    }
+}
+
+/// <summary>
+/// Enable or disable an already configured proxy.
+/// </summary>
+/// <param name="enableProxy">To enable or disable proxy. Set to true to enable, and false to
+/// disable proxy</param>
+void dx_azureEnableProxy(bool enableProxy)
+{
+    int result = -1;
+    Networking_ProxyConfig  *proxyConfig = Networking_Proxy_Create();
+    if (proxyConfig == NULL) {
+        Log_Debug("ERROR: Networking_Proxy_Create(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Need to get the current config, otherwise the existing config will get overwritten with a
+    // blank/default config when the change is applied.
+    if (Networking_Proxy_Get(proxyConfig) == -1) {
+
+        if (errno == ENOENT) {
+            Log_Debug("There is currently no proxy configured.\n");
+        } else {
+            Log_Debug("ERROR: Networking_Proxy_Get(): %d (%s)\n", errno, strerror(errno));
+        }
+        goto cleanup;
+    }
+
+    // Get the proxy options.
+    Networking_ProxyOptions proxyOptions = 0;
+    if (Networking_Proxy_GetProxyOptions(proxyConfig, &proxyOptions) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_GetProxyOptions(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Set the enabled/disabled proxy option.
+    if (enableProxy) {
+        // Set flag Networking_ProxyOptions_Enabled;
+        proxyOptions |= Networking_ProxyOptions_Enabled;
+    } else {
+        // Reset flag Networking_ProxyOptions_Enabled;
+        proxyOptions &= ~((unsigned int)Networking_ProxyOptions_Enabled);
+    }
+
+    if (Networking_Proxy_SetProxyOptions(proxyConfig, proxyOptions) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_SetProxyOptions(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Apply the proxy configuration.
+    if (Networking_Proxy_Apply(proxyConfig) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_Apply(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+    result = 0;
+
+cleanup:
+    if (proxyConfig) {
+        Networking_Proxy_Destroy(proxyConfig);
+    }
+    
+    // If we encountered any errors exit and return the exit reason to the OS
+    if(result != 0){
+        dx_terminate(DX_ExitCode_Enable_Disable_Proxy_Failed);
+    }
 }

--- a/src/dx_proxy.c
+++ b/src/dx_proxy.c
@@ -1,0 +1,234 @@
+#include "dx_proxy.h"
+
+// Keep a pointer to the proxy configuration+
+static DX_PROXY_PROPERTIES *_proxyConfig = NULL;
+
+/// <summary>
+/// Establish IoTHub connection using MQTT WebSocket.  Required when the Sphere device is using a web proxy
+/// </summary>
+/// <param name="proxyProperties"></param>
+bool dx_proxyOpenIoTHubHandleWithMqttWebSocket(const char *hostname,
+                                               IOTHUB_DEVICE_CLIENT_LL_HANDLE *iothubClientHandle)
+{
+    
+    IOTHUB_CLIENT_RESULT iothubResult;
+
+    *iothubClientHandle =
+        IoTHubDeviceClient_LL_CreateWithAzureSphereFromDeviceAuth(hostname, MQTT_WebSocket_Protocol);
+
+    if (*iothubClientHandle == NULL) {
+        Log_Debug("ERROR: IoTHubDeviceClient_LL_CreateFromDeviceAuth returned NULL.\n");
+        return false;
+    }
+
+    HTTP_PROXY_OPTIONS httpProxyOptions;
+    memset(&httpProxyOptions, 0, sizeof(httpProxyOptions));
+    httpProxyOptions.host_address = _proxyConfig->proxyAddress;
+    httpProxyOptions.port = _proxyConfig->proxyPort;
+
+    if ((iothubResult = IoTHubDeviceClient_LL_SetOption(
+        *iothubClientHandle, OPTION_HTTP_PROXY, &httpProxyOptions)) != IOTHUB_CLIENT_OK) {
+        Log_Debug("ERROR: Failure setting Azure IoT Hub client option  \"OPTION_HTTP_PROXY\": %s\n",
+            IOTHUB_CLIENT_RESULTStrings(iothubResult));
+            return false;
+    }
+
+    return true;
+}
+
+
+/// <summary>
+/// Configure Proxy Settings
+/// </summary>
+/// <param name="proxyProperties"></param>
+void dx_proxyConfigureProxy(DX_PROXY_PROPERTIES *proxyProperties)
+{
+    int result = -1;
+
+    // Verify we have a valid input
+    if(proxyProperties == NULL){
+        goto cleanup;
+    }
+
+    // By default, proxy configuration option Networking_ProxyOptions_Enabled is set and the proxy
+    // type is Networking_ProxyType_HTTP.
+    Networking_ProxyConfig *proxyConfig = Networking_Proxy_Create();
+    if (proxyConfig == NULL) {
+        Log_Debug("ERROR: Networking_Proxy_Create(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Set the proxy address and port.
+    if (Networking_Proxy_SetProxyAddress(proxyConfig, proxyProperties->proxyAddress, proxyProperties->proxyPort) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_SetProxyAddress(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // If both username and password are set, use basic authentication. Otherwise use anonymous
+    // authentication.
+    if ((proxyProperties->proxyUsername != NULL) && (proxyProperties->proxyPassword != NULL)) {
+        if (Networking_Proxy_SetBasicAuthentication(proxyConfig, proxyProperties->proxyUsername, proxyProperties->proxyPassword) ==
+            -1) {
+            Log_Debug("ERROR: Networking_Proxy_SetBasicAuthentication(): %d (%s)\n", errno,
+                      strerror(errno));
+            goto cleanup;
+        }
+    } else {
+        if (Networking_Proxy_SetAnonymousAuthentication(proxyConfig) == -1) {
+            Log_Debug("ERROR: Networking_Proxy_SetAnonymousAuthentication(): %d (%s)\n", errno,
+                      strerror(errno));
+            goto cleanup;
+        }
+    }
+
+    // Set addresses for which proxy should not be used if "noProxyAddresses" is modified.
+    if (proxyProperties->noProxyAdresses != NULL) {
+        if (Networking_Proxy_SetProxyNoProxyAddresses(proxyConfig, proxyProperties->noProxyAdresses) == -1) {
+            Log_Debug("ERROR: Networking_Proxy_SetProxyNoProxyAddresses(): %d (%s)\n", errno,
+                      strerror(errno));
+            goto cleanup;
+        }
+    }
+
+    // Apply the proxy configuration.
+    if (Networking_Proxy_Apply(proxyConfig) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_Apply(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // The proxy settings were all applied without any issues.  Update the _proxyConfig pointer
+    // to use while the proxy is active
+    _proxyConfig = proxyProperties;
+    result = 0;
+
+cleanup:
+    if (proxyConfig) {
+        Networking_Proxy_Destroy(proxyConfig);
+    }
+
+    // If we encountered any errors exit and return the exit reason to the OS
+    if(result != 0){
+        dx_terminate(DX_ExitCode_Configure_Proxy_Failed);
+    }
+}
+
+/// <summary>
+/// Enable or disable an already configured proxy.
+/// </summary>
+/// <param name="enableProxy">To enable or disable proxy. Set to true to enable, and false to
+/// disable proxy</param>
+void dx_proxyEnableProxy(bool enableProxy)
+{
+    int result = -1;
+
+    // Verify that the proxy configuration has been set
+    if(_proxyConfig == NULL){
+        goto cleanup;
+    }
+
+    Networking_ProxyConfig  *proxyConfig = Networking_Proxy_Create();
+    if (proxyConfig == NULL) {
+        Log_Debug("ERROR: Networking_Proxy_Create(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Need to get the current config, otherwise the existing config will get overwritten with a
+    // blank/default config when the change is applied.
+    if (Networking_Proxy_Get(proxyConfig) == -1) {
+
+        if (errno == ENOENT) {
+            Log_Debug("There is currently no proxy configured.\n");
+        } else {
+            Log_Debug("ERROR: Networking_Proxy_Get(): %d (%s)\n", errno, strerror(errno));
+        }
+        goto cleanup;
+    }
+
+    // Get the proxy options.
+    Networking_ProxyOptions proxyOptions = 0;
+    if (Networking_Proxy_GetProxyOptions(proxyConfig, &proxyOptions) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_GetProxyOptions(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Set the enabled/disabled proxy option.
+    if (enableProxy) {
+        // Set flag Networking_ProxyOptions_Enabled;
+        proxyOptions |= Networking_ProxyOptions_Enabled;
+        _proxyConfig->proxyEnabled = true;
+    } else {
+        // Reset flag Networking_ProxyOptions_Enabled;
+        proxyOptions &= ~((unsigned int)Networking_ProxyOptions_Enabled);
+        _proxyConfig->proxyEnabled = false;
+    }
+
+    if (Networking_Proxy_SetProxyOptions(proxyConfig, proxyOptions) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_SetProxyOptions(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    // Apply the proxy configuration.
+    if (Networking_Proxy_Apply(proxyConfig) == -1) {
+        Log_Debug("ERROR: Networking_Proxy_Apply(): %d (%s)\n", errno, strerror(errno));
+        goto cleanup;
+    }
+    result = 0;
+
+cleanup:
+    if (proxyConfig) {
+        Networking_Proxy_Destroy(proxyConfig);
+    }
+    
+    // If we encountered any errors exit and return the exit reason to the OS
+    if(result != 0){
+        dx_terminate(DX_ExitCode_Enable_Disable_Proxy_Failed);
+    }
+}
+
+
+/// <summary>
+/// Create the DPS provisioning handle using MQTT over a Web Socket.  Required when the Sphere 
+/// device is using a web proxy
+/// </summary>
+/// <param name="prov_handle"></param>
+bool dx_proxyCreateDpsClientWithMqttWebSocket(const char *dpsUrl, 
+                                              const char *idScope, 
+                                              PROV_DEVICE_LL_HANDLE *prov_handle)
+{
+    // Create Provisioning Client for communication with DPS
+    // using MQTT protocol
+    *prov_handle = Prov_Device_LL_Create(dpsUrl, idScope, Prov_Device_MQTT_WS_Protocol);
+    if (prov_handle == NULL) {
+        Log_Debug("ERROR: Failed to create Provisioning Client\n");
+        return false;
+    }
+
+    // Use DAA cert in provisioning flow - requires the SetDeviceId option to be set on the
+    // provisioning client.
+    static const int deviceIdForDaaCertUsage = 1;
+    PROV_DEVICE_RESULT prov_result =
+        Prov_Device_LL_SetOption(*prov_handle, "SetDeviceId", &deviceIdForDaaCertUsage);
+    if (prov_result != PROV_DEVICE_RESULT_OK) {
+        Log_Debug("ERROR: Failed to set Device ID in Provisioning Client\n");
+        return false;
+    }
+
+    HTTP_PROXY_OPTIONS httpProxyOptions;
+    memset(&httpProxyOptions, 0, sizeof(httpProxyOptions));
+    httpProxyOptions.host_address = _proxyConfig->proxyAddress;
+    httpProxyOptions.port = _proxyConfig->proxyPort;
+    prov_result = Prov_Device_LL_SetOption(*prov_handle, OPTION_HTTP_PROXY, &httpProxyOptions);
+    if (prov_result != PROV_DEVICE_RESULT_OK) {
+        Log_Debug("ERROR: Failed to set Proxy options in Provisioning Client\n");
+        return false;
+    }
+
+    return true;
+}
+
+/// <summary>
+/// Return the status of the web proxy, enabled (true) or disabled (false).
+/// </summary>
+bool dx_proxyIsEnabled(void){
+    return _proxyConfig->proxyEnabled;
+}


### PR DESCRIPTION
Add proxy support as released in the 22.02 release.  I've used the samples from [azure-sphere-samples - CodeSnipits](https://github.com/Azure/azure-sphere-samples/tree/main/CodeSnippets/Networking/Proxy) folder, and instructions from the [AzureIoT Example to add proxy support](https://github.com/Azure/azure-sphere-samples/blob/main/Samples/AzureIoT/READMEAddWebProxy.md) README.md file as a guide.  I've tested this implementation with a proxy server that does not require any authentication.
