### PR TITLE
Async events to event loop thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ PROJECT(azure_sphere_devx C)
 # Source groups
 ################################################################################
 set(Source
+    "./src/dx_async.c"
     "./src/dx_azure_iot.c"
     "./src/dx_config.c"
     "./src/dx_device_twins.c"

--- a/include/dx_async.h
+++ b/include/dx_async.h
@@ -1,0 +1,29 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#pragma once
+
+#include "dx_terminate.h"
+#include <pthread.h>
+#include <stdbool.h>
+
+extern volatile sig_atomic_t terminationRequired;
+
+#define DX_ASYNC_HANDLER(name, handle)  \
+    void name(DX_ASYNC_BINDING *handle) \
+    {
+
+#define DX_ASYNC_HANDLER_END }
+
+#define DX_DECLARE_ASYNC_HANDLER(name) void name(DX_ASYNC_BINDING *handle)
+
+typedef struct _asyncBinding {
+    bool triggered;
+    void *data;
+    void (*handler)(struct _asyncBinding *handle);
+} DX_ASYNC_BINDING;
+
+void dx_asyncInit(DX_ASYNC_BINDING *async);
+void dx_asyncSend(DX_ASYNC_BINDING *binding, void *data);
+void dx_asyncSetInit(DX_ASYNC_BINDING *asyncSet[], size_t asyncCount);
+void dx_asyncRunEvents(void);

--- a/include/dx_terminate.h
+++ b/include/dx_terminate.h
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <time.h>
 
-// volatile sig_atomic_t terminationRequired = false;
+extern volatile bool asyncEventReady;
 
 bool dx_isTerminationRequired(void);
 int dx_getTerminationExitCode(void);

--- a/src/dx_async.c
+++ b/src/dx_async.c
@@ -1,0 +1,53 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+#include "dx_async.h"
+
+static DX_ASYNC_BINDING **_asyncSet = NULL;
+static size_t _asyncCount = 0;
+volatile bool asyncEventReady = false;
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void dx_asyncInit(DX_ASYNC_BINDING *binding)
+{
+    binding->triggered = false;
+    binding->data = NULL;
+}
+
+void dx_asyncSend(DX_ASYNC_BINDING *binding, void *data)
+{
+    pthread_mutex_lock(&mutex);
+    binding->data = data;
+    binding->triggered = true;
+    asyncEventReady = true;
+    pthread_mutex_unlock(&mutex);
+}
+
+void dx_asyncSetInit(DX_ASYNC_BINDING *asyncSet[], size_t asyncCount)
+{
+    if (asyncCount < 0) {
+        return;
+    }
+
+    _asyncCount = asyncCount;
+    _asyncSet = asyncSet;
+
+    for (int i = 0; i < asyncCount; i++) {
+        dx_asyncInit(asyncSet[i]);
+    }
+}
+
+void dx_asyncRunEvents(void)
+{
+    pthread_mutex_lock(&mutex);
+
+    for (int i = 0; i < _asyncCount; i++) {
+        if (_asyncSet[i]->triggered && _asyncSet[i]->handler) {
+            _asyncSet[i]->handler(_asyncSet[i]);
+            _asyncSet[i]->triggered = false;
+        }
+    }
+
+    asyncEventReady = false;
+    pthread_mutex_unlock(&mutex);
+}


### PR DESCRIPTION
@bwilless Async provides a mechanism to marshal an event from a thread to the main thread. This is exists primarily to support calling event loop functions from a thread, though there are other use cases.

Event loop functions (for example set a oneshot timer) must be called from the same thread the event loop is running on, by default the main thread. Failure to so will result in bad undefined things eventually happening.